### PR TITLE
feat: 로컬 환경 셋업 + Kafka SSL + .gitignore 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DB_URL=localhost:5439/delivery_db
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+EUREKA_SERVER_URL=http://localhost:18761/eureka
+BOOTSTRAP_SERVERS=<GCP Kafka broker public IPs (콤마 구분)>
+KAFKA_BOOTSTRAP_SERVERS=<위와 동일>
+TRUST_STORE_PASSWORD=<truststore 비번 — 팀 슬랙 별도 공유>

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,10 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Environment & Secrets ###
+.env
+!.env.example
+
+### Kafka SSL truststore (gitignored, 팀 슬랙 별도 공유) ###
+src/main/resources/ssl/

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'org.postgresql:postgresql'
     implementation 'com.loopang:common:0.0.5-SNAPSHOT'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,48 @@ spring:
         enabled: true
         service-id: config-server
 
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_URL:localhost:5439/delivery_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+  jpa:
+    hibernate:
+      ddl-auto: ${DB_DDL_AUTO:update}
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+  kafka:
+    bootstrap-servers: ${BOOTSTRAP_SERVERS}
+    properties:
+      security.protocol: SSL
+      ssl.endpoint.identification.algorithm: ""
+    ssl:
+      trust-store-location: classpath:ssl/kafka.server.truststore.jks
+      trust-store-password: ${TRUST_STORE_PASSWORD}
+      trust-store-type: PKCS12
+    producer:
+      acks: all
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      properties:
+        enable.idempotence: true
+        max.block.ms: 10000
+        max.in.flight.requests.per.connection: 5
+        retries: 3
+        delivery.timeout.ms: 120000
+    consumer:
+      group-id: delivery-group
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      auto-offset-reset: earliest
+    listener:
+      ack-mode: manual
+      concurrency: 3
+
 eureka:
   client:
     fetch-registry: true
@@ -21,4 +63,11 @@ eureka:
 
 server:
   port: 18099
+
+topics:
+  order:
+    accepted: ${TOPICS_ORDER_ACCEPTED:dev-order-accepted}
+  delivery:
+    created: ${TOPICS_DELIVERY_CREATED:dev-delivery-created}
+    status-updated: ${TOPICS_DELIVERY_STATUS_UPDATED:dev-delivery-status-updated}
 


### PR DESCRIPTION
## 배경

다른 도메인 서비스(hub/user/company 등)와 동일한 로컬 개발 환경 패턴으로 delivery-service를 정렬합니다. 기존엔 \`spring-dotenv\` 의존성이 없어 \`.env\` 파일 자동 로드가 안 됐고, Kafka SSL 설정도 빠져 있어 GCP Kafka에 붙을 수 없었습니다.

## 변경 내용

### \`build.gradle\`
- \`me.paulschwarz:spring-dotenv:4.0.0\` 추가 — 모듈 root의 \`.env\` 파일 자동 로드

### \`application.yaml\`
- \`spring.datasource\` + \`spring.jpa\` 설정 추가 (Config Server 의존 최소화 + 로컬 default 값 명시)
- \`spring.kafka\`에 SSL 설정 추가 (GCP Kafka 연동 필수):
  - \`security.protocol: SSL\`
  - \`ssl.trust-store-location: classpath:ssl/kafka.server.truststore.jks\`
  - \`ssl.trust-store-type: PKCS12\` ← 파일명은 \`.jks\`이지만 실제 형식이 PKCS12라 명시 안 하면 "keystore password was incorrect" 에러로 위장됨
- consumer 설정 보강 (\`group-id\`, \`auto-offset-reset\`, \`listener.ack-mode\` 등)
- \`topics\` 섹션 추가 (\`order.accepted\`, \`delivery.created\`, \`delivery.status-updated\`)

### \`.gitignore\`
- \`.env\` (시크릿) 차단
- \`src/main/resources/ssl/\` (truststore) 차단
- \`!.env.example\` 허용

### \`.env.example\` (신규)
- 로컬 환경 변수 템플릿. 실제 \`.env\`는 gitignored.

## 주의사항

이 PR을 머지한 후 로컬에서 띄우려면:
1. 모듈 root에 \`.env\` 파일 작성 (\`.env.example\` 참고)
2. \`src/main/resources/ssl/kafka.server.truststore.jks\` 파일 배치 (팀 슬랙에서 수령)
3. IntelliJ Run Configuration에서 **Working directory**를 모듈 절대 경로로 설정 — 멀티모듈 IntelliJ 프로젝트에서 spring-dotenv가 \`.env\`를 찾도록

또한 \`UserFeignClient\`의 \`contextId\` 중복 fix는 별도 PR로 올라옵니다 (CourierFeignClient와 동일 contextId 사용해서 빈 중복 등록 발생).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 애플리케이션의 배포 및 환경 설정이 개선되었습니다. 데이터베이스, 메시징 시스템, 그리고 보안 설정을 위한 환경 변수 템플릿이 추가되어 초기 구성이 용이합니다. 개발 환경 설정 파일 관리가 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->